### PR TITLE
update adm-zip to 0.4.7 for Node.js v4

### DIFF
--- a/.bmp.yml
+++ b/.bmp.yml
@@ -1,0 +1,4 @@
+---
+version: 1.5.1
+files:
+  package.json: '"version": "%.%.%",'

--- a/.releaseignore
+++ b/.releaseignore
@@ -1,0 +1,8 @@
+node_modules
+.editorconfig
+test/packer/build
+test/runtime/build
+tmp
+.releaseignore
+npm-debug.log
+!test/**/node_modules

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+general:
+    branches:
+        ignore:
+            - gh-pages
+            - '/release.*/'
+machine:
+    environment:
+        PATH: '$PATH:$HOME/$CIRCLE_PROJECT_REPONAME/node_modules/node-circleci-autorelease/bin'
+        VERSION_PREFIX: cureapp-
+        GH_PAGES_DIR: doc
+    pre:
+        - "git config --global user.name 'CircleCI'"
+        - "git config --global user.email 'circleci@cureapp.jp'"
+dependencies:
+    post:
+        - npm run post-dependencies
+deployment:
+    create_release_branch:
+        branch:
+            - master
+        commands:
+            - 'cc-prepare-for-release && npm run pre-release && cc-release || cc-not-released'
+            - cc-gh-pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titaniumifier",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Get a Titanium SDK CommonJS module out of a Node package!",
   "author": {
     "name": "Pier Paolo Ramon",
@@ -20,7 +20,15 @@
   },
   "scripts": {
     "test": "grunt test",
-    "prepublish": "node lib/scripts/prepublish.js"
+    "prepublish": "node lib/scripts/prepublish.js",
+    "bmp-p": "cc-bmp -p",
+    "bmp-m": "cc-bmp -m",
+    "bmp-j": "cc-bmp -j",
+    "circle": "cc-generate-yml",
+    "post-dependencies": "echo post-dependencies",
+    "pre-release": "node lib/scripts/prepublish.js",
+    "post-release": "echo post-release",
+    "gh-pages": "echo gh-pages"
   },
   "keywords": [
     "titanium",
@@ -57,10 +65,21 @@
     "grunt-zip": "^0.17.0",
     "longjohn": "^0.2.4",
     "moment": "^2.5.1",
+    "node-circleci-autorelease": "^1.5.5",
     "reduce": "^1.0.1",
     "reduce-component": "^1.0.1",
     "should": "^7.0.2",
     "ti-mocha": "^0.2.0",
     "uglify-js": "^1.3.5"
+  },
+  "node-circleci-autorelease": {
+    "config": {
+      "git-user-name": "CircleCI",
+      "git-user-email": "circleci@cureapp.jp",
+      "version-prefix": "cureapp-",
+      "create-branch": false,
+      "create-gh-pages": false,
+      "gh-pages-dir": "doc"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "analysis"
   ],
   "dependencies": {
-    "adm-zip": "0.4.6",
+    "adm-zip": "0.4.7",
     "bluebird": "^2.5.1",
     "browserify": "^11.0.1",
     "commander": "^2.5.1",


### PR DESCRIPTION
Hi,

thank you for developing a nice repo. 

`fidonet-mailer-binkp-crypt`, which is included as dependencies in `adm-zip@0.4.6`,  is no longer available at Node v4.

`adm-zip@0.4.7 ` has removed dependencies on `fidonet-mailer-binkp-crypt`, and works well.

I'd like titaniumifier to use newer version of adm-zip.