### PR TITLE
update adm-zip to 0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "analysis"
   ],
   "dependencies": {
-    "adm-zip": "0.4.6",
+    "adm-zip": "0.4.7",
     "bluebird": "^2.5.1",
     "browserify": "^11.0.1",
     "commander": "^2.5.1",


### PR DESCRIPTION
Hi,

thank you for developing a nice repo.

fidonet-mailer-binkp-crypt, which is included as dependencies in adm-zip@0.4.6, is no longer available at Node v4.

adm-zip@0.4.7 has removed dependencies on fidonet-mailer-binkp-crypt, and works well.

I'd like titaniumifier to use newer version of adm-zip.