### PR TITLE
Resolves empty zip problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "analysis"
   ],
   "dependencies": {
-    "adm-zip": "0.4.7",
+    "adm-zip": "0.4.11",
     "bluebird": "^2.5.1",
     "browserify": "^11.0.1",
     "commander": "^2.5.1",


### PR DESCRIPTION
Node version v8.11.1
While generating zip file, all the files were empty.
Updating this package resolves the problem.